### PR TITLE
 docker: pin base image, run as non-root user, add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Git
+.git
+.github
+
+# Frontend depencencies and build output
+web/node_modules
+web/dist
+
+#Documentation
+docs
+*.md
+
+# Secrets 
+.env
+.env.*
+!.env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,17 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o api main.go
 
-FROM alpine:latest
+FROM alpine:3.24.1
 
 WORKDIR /app
 
+RUN addgroup -S tsz && adduser -S tsz -G tsz
+
 COPY --from=builder /app/api .
+
+RUN chown tsz:tsz /app/api
+
+USER tsz
 
 EXPOSE 8080
 


### PR DESCRIPTION
## What changed

Hardens the Docker setup for the TSZ API service:

- Added `.dockerignore` — excludes `.git`, `web/node_modules`, `web/dist`,
  `docs/`, markdown files, and `.env`/`.env.*` from the build context.
- Pinned the runtime base image: `alpine:latest` → `alpine:3.24.1`.
- Run the container as a non-root user (`tsz:tsz`), implementing the task
  listed in `SECURITY_ROADMAP.md` → Milestone 7.3 "Run as non-root user in
  Docker".

No application code changed; no breaking changes.

## Why

- **`.dockerignore`**: without it, the full repo (including `.git` history
  and, if present locally, `.env`) is sent to the Docker daemon as build
  context. Even though `.env` never ends up in the final image, it could
  still land in an intermediate builder layer/cache — this closes that gap
  and also keeps builds faster by trimming unrelated files (frontend
  `node_modules`, docs).
- **Pinned `alpine` version**: `latest` is a moving target — a rebuild
  next month could silently pull a different Alpine release, making builds
  non-reproducible and debugging harder if something breaks upstream.
- **Non-root user**: running as root inside the container means a
  compromised process has root privileges within that container's
  namespace. Running as `tsz` limits the blast radius — verified below
  that `tsz` can't even write to `/app`.

## Testing

- `docker build` / `docker-compose up --build -d` succeed; `/healthz`,
  `/ready`, `/detect` all verified working.
- Confirmed `.env` never ends up inside the built image
  (`find / -name '.env'` → empty).
- Confirmed non-root: `id` → `uid=100(tsz)`; default `whoami` (no `-u`
  override) → `tsz`; `tsz` cannot write to `/app`.
- Verified across `docker restart` as well.

