### PR TITLE
security(docker): exact USER tsz:tsz syntax + read-only root filesystem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY --from=builder /app/api .
 
 RUN chown tsz:tsz /app/api
 
-USER tsz
+USER tsz:tsz
 
 EXPOSE 8080
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: Dockerfile
     image: thyris-sz:local
     container_name: thyris_api
+    read_only: true
     environment:
       - DB_DSN=postgres://postgres:postgres@db:5432/thyris?sslmode=disable&TimeZone=Europe/Istanbul
       - REDIS_URL=redis://:thyrisredis@redis:6379/0


### PR DESCRIPTION
## What changed

Completes the remaining `SECURITY_ROADMAP.md` Milestone 7.3 items:

- `USER tsz` → `USER tsz:tsz` (exact syntax match, no behavior change)
- Added `read_only: true` to the `api` service in `docker-compose.yml`

`db`/`redis` are untouched — they're official images that need disk
write access for persistence, so read-only doesn't apply to them.

## Why

Read-only root filesystem limits what a compromised process can do,
even beyond non-root. `api` was a safe candidate since it never writes
to disk (confirmed via code search, all state lives in Postgres/Redis).

## Testing

- `docker inspect --format '{{.HostConfig.ReadonlyRootfs}}'` → `true`
- Confirmed writes fail everywhere (`/app`, `/tmp`), not just via
  permissions but at the filesystem level
- `/healthz`, `/ready`, `/detect` all verified working