### PR TITLE
spesifised resource limits in the values.yaml file

### DIFF
--- a/deployment/helm/thyris-sz/values.yaml
+++ b/deployment/helm/thyris-sz/values.yaml
@@ -45,7 +45,10 @@ ingress:
           pathType: Prefix
   tls: []
 
-resources: {}
+resources:
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
 
 autoscaling:
   enabled: false
@@ -128,7 +131,10 @@ postgresql:
     enabled: true
     size: 8Gi
     storageClass: ""
-  resources: {}
+  resources:
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
 
 redis:
   enabled: true
@@ -144,4 +150,7 @@ redis:
     enabled: false
     size: 2Gi
     storageClass: ""
-  resources: {}
+  resources:
+    limits:
+      memory: "512Mi"
+      cpu: "500m"


### PR DESCRIPTION
## What changed

This PR completes the last remaining item under Milestone 7.3 "Runtime Security": **"Set resource limits (memory, CPU)"**.

Resource definitions (`memory: 512Mi`, `cpu: 500m`) were added to the relevant sections in `values.yaml` for `thyris-sz` (api), `postgresql`, and `redis`.

## Testing

Tested locally (minikube) by simulating a scenario of 1000 concurrent requests. Verified that resource usage stayed within the defined limits.

## Milestone 7.3 status

With this PR, all sub-tasks under **7.3 Runtime Security** are now complete:

- ✅ Run as non-root user in Docker — #41, #43
- ✅ Use read-only root filesystem where possible — #43
- ✅ Set resource limits (memory, CPU) — this PR

If there's nothing missing from your side, I'm happy to follow up with a commit marking item 7.3 as complete in `SECURITY_ROADMAP.md`.